### PR TITLE
You'll want to specify the version of nasapower

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.1
 Imports:
-    nasapower,
+    nasapower (>= 4.0.0),
     plyr,
     rgdal,
     doParallel,


### PR DESCRIPTION
Because of the changes to the POWER API, anything before 4.0.0 won't work any longer, so you should be specifying a minimum version of this package as an Import.